### PR TITLE
Removing spec.icon from the operator bundle for passing CVP

### DIFF
--- a/bundle/manifests/dpu-network-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dpu-network-operator.clusterserviceversion.yaml
@@ -11,6 +11,7 @@ metadata:
             "name": "ovnkubeconfig-sample"
           },
           "spec": {
+            "kubeConfigFile": "tenant-cluster-1-kubeconf",
             "nodeSelector": {
               "matchLabels": {
                 "node-role.kubernetes.io/dpu-worker": ""
@@ -46,9 +47,6 @@ spec:
   description: The operator to be responsible for the life-cycle management of the
     ovn-kube components and the necessary host network initialization on DPU cards.
   displayName: DPU Network Operator
-  icon:
-  - base64data: ""
-    mediatype: ""
   install:
     spec:
       clusterPermissions:

--- a/config/manifests/bases/dpu-network-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/dpu-network-operator.clusterserviceversion.yaml
@@ -29,9 +29,6 @@ spec:
   description: The operator to be responsible for the life-cycle management of the
     ovn-kube components and the necessary host network initialization on DPU cards.
   displayName: DPU Network Operator
-  icon:
-  - base64data: ""
-    mediatype: ""
   install:
     spec:
       deployments: null


### PR DESCRIPTION
We will add the icon field back, when it is avaliable.