### PR TITLE
Add arm64 label

### DIFF
--- a/bundle/manifests/dpu-network-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dpu-network-operator.clusterserviceversion.yaml
@@ -33,6 +33,8 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/dpu-network-operator
     support: Red Hat
+  labels:
+    operatorframework.io/arch.arm64: supported
   name: dpu-network-operator.v0.0.1
   namespace: placeholder
 spec:

--- a/config/manifests/bases/dpu-network-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/dpu-network-operator.clusterserviceversion.yaml
@@ -15,6 +15,8 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/dpu-network-operator
     support: Red Hat
+  labels:
+    operatorframework.io/arch.arm64: supported
   name: dpu-network-operator.v0.0.1
   namespace: placeholder
 spec:

--- a/manifests/stable/dpu-network-operator.clusterserviceversion.yaml
+++ b/manifests/stable/dpu-network-operator.clusterserviceversion.yaml
@@ -33,6 +33,8 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/dpu-network-operator
     support: Red Hat
+  labels:
+    operatorframework.io/arch.arm64: supported
   name: dpu-network-operator.v0.0.1
   namespace: placeholder
 spec:


### PR DESCRIPTION
This will cause the DPU Operator to be displayed only on ARM clusters, as that is the only arch on which this is supported.

In order to cherry-pick this back to 4.10, this will require a BZ.
