### PR TITLE
Bug 2090549: add amd64 label

### DIFF
--- a/bundle/manifests/dpu-network-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dpu-network-operator.clusterserviceversion.yaml
@@ -35,6 +35,7 @@ metadata:
     support: Red Hat
   labels:
     operatorframework.io/arch.arm64: supported
+    operatorframework.io/arch.amd64: supported
   name: dpu-network-operator.v4.11.0
   namespace: placeholder
 spec:

--- a/config/manifests/bases/dpu-network-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/dpu-network-operator.clusterserviceversion.yaml
@@ -17,6 +17,7 @@ metadata:
     support: Red Hat
   labels:
     operatorframework.io/arch.arm64: supported
+    operatorframework.io/arch.amd64: supported
   name: dpu-network-operator.v0.0.1
   namespace: placeholder
 spec:

--- a/manifests/stable/dpu-network-operator.clusterserviceversion.yaml
+++ b/manifests/stable/dpu-network-operator.clusterserviceversion.yaml
@@ -35,6 +35,7 @@ metadata:
     support: Red Hat
   labels:
     operatorframework.io/arch.arm64: supported
+    operatorframework.io/arch.amd64: supported
   name: dpu-network-operator.v4.11.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
Allow operator to run on amd arch in hypershift management cluster