### PR TITLE
Use "go install" rather than "go get"

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.17-openshift-4.11
+  tag: rhel-8-release-golang-1.18-openshift-4.11

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/dpu-network-operator
 
-go 1.17
+go 1.18
 
 require (
 	github.com/k8snetworkplumbingwg/sriov-network-operator v1.0.0


### PR DESCRIPTION
As of go 1.18, "go get" no longer installs.

(Fixes #29)