### PR TITLE
Bump to 4.13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 4.12.0
+VERSION ?= 4.13.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/dpu-network-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dpu-network-operator.clusterserviceversion.yaml
@@ -24,11 +24,11 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional, Networking
     certified: "false"
-    containerImage: quay.io/openshift/origin-dpu-network-operator:4.12
+    containerImage: quay.io/openshift/origin-dpu-network-operator:4.13
     createdAt: "2023-02-08T16:16:28Z"
     description: The operator is responsible for the life-cycle management of the
       ovn-kube components and the necessary host network initialization on DPU cards.
-    olm.skipRange: '>=4.10.0-0 <4.12.0'
+    olm.skipRange: '>=4.10.0-0 <4.13.0'
     operators.operatorframework.io/builder: operator-sdk-v1.26.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/dpu-network-operator
@@ -36,7 +36,7 @@ metadata:
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
-  name: dpu-network-operator.v4.12.0
+  name: dpu-network-operator.v4.13.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -221,7 +221,7 @@ spec:
                       fieldPath: metadata.namespace
                 - name: TENANT_NAMESPACE
                   value: openshift-ovn-kubernetes
-                image: quay.io/openshift/origin-dpu-network-operator:4.12
+                image: quay.io/openshift/origin-dpu-network-operator:4.13
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -316,4 +316,4 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  version: 4.12.0
+  version: 4.13.0

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/openshift/origin-dpu-network-operator
-  newTag: "4.12"
+  newTag: "4.13"

--- a/config/manifests/bases/dpu-network-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/dpu-network-operator.clusterserviceversion.yaml
@@ -6,11 +6,11 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional, Networking
     certified: "false"
-    containerImage: quay.io/openshift/origin-dpu-network-operator:4.12
+    containerImage: quay.io/openshift/origin-dpu-network-operator:4.13
     createdAt: 2021/10/15
     description: The operator is responsible for the life-cycle management of the
       ovn-kube components and the necessary host network initialization on DPU cards.
-    olm.skipRange: '>=4.10.0-0 <4.12.0'
+    olm.skipRange: '>=4.10.0-0 <4.13.0'
     operators.operatorframework.io/builder: operator-sdk-v1.13.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/dpu-network-operator

--- a/manifests/dpu-network-operator.package.yaml
+++ b/manifests/dpu-network-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: dpu-network-operator
 channels:
 - name: "stable"
-  currentCSV: dpu-network-operator.v4.10.0
+  currentCSV: dpu-network-operator.v4.13.0

--- a/manifests/stable/dpu-network-operator.clusterserviceversion.yaml
+++ b/manifests/stable/dpu-network-operator.clusterserviceversion.yaml
@@ -24,11 +24,11 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional, Networking
     certified: "false"
-    containerImage: quay.io/openshift/origin-dpu-network-operator:4.12
+    containerImage: quay.io/openshift/origin-dpu-network-operator:4.13
     createdAt: "2023-02-08T16:16:27Z"
     description: The operator is responsible for the life-cycle management of the
       ovn-kube components and the necessary host network initialization on DPU cards.
-    olm.skipRange: '>=4.10.0-0 <4.12.0'
+    olm.skipRange: '>=4.10.0-0 <4.13.0'
     operators.operatorframework.io/builder: operator-sdk-v1.26.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/dpu-network-operator
@@ -36,7 +36,7 @@ metadata:
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.arm64: supported
-  name: dpu-network-operator.v4.12.0
+  name: dpu-network-operator.v4.13.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -221,7 +221,7 @@ spec:
                       fieldPath: metadata.namespace
                 - name: TENANT_NAMESPACE
                   value: openshift-ovn-kubernetes
-                image: quay.io/openshift/origin-dpu-network-operator:4.12
+                image: quay.io/openshift/origin-dpu-network-operator:4.13
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -316,4 +316,4 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  version: 4.12.0
+  version: 4.13.0

--- a/manifests/stable/image-references
+++ b/manifests/stable/image-references
@@ -6,7 +6,7 @@ spec:
   - name: dpu-network-operator
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-dpu-network-operator:4.11
+      name: quay.io/openshift/origin-dpu-network-operator:4.13
   - name: kube-rbac-proxy
     from:
       kind: DockerImage


### PR DESCRIPTION
The operator [is currently disabled in ART's config for 4.13](https://github.com/openshift/ocp-build-data/blob/openshift-4.13/images/dpu-network-operator.yml#L1). It can be safely re-enabled once version is bumped

Ref. https://issues.redhat.com/browse/ART-5087