### PR TITLE
We should run on host network in order to be able to run normally in infra cluster

### DIFF
--- a/bundle/manifests/dpu-network-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dpu-network-operator.clusterserviceversion.yaml
@@ -25,11 +25,11 @@ metadata:
     categories: OpenShift Optional, Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-dpu-network-operator:4.12
-    createdAt: "2022-12-27T13:05:54Z"
+    createdAt: "2023-01-27T12:43:45Z"
     description: The operator is responsible for the life-cycle management of the
       ovn-kube components and the necessary host network initialization on DPU cards.
     olm.skipRange: '>=4.10.0-0 <4.12.0'
-    operators.operatorframework.io/builder: operator-sdk-v1.26.0
+    operators.operatorframework.io/builder: operator-sdk-v1.26.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/dpu-network-operator
     support: Red Hat
@@ -156,6 +156,7 @@ spec:
           - security.openshift.io
           resourceNames:
           - anyuid
+          - hostnetwork
           resources:
           - securitycontextconstraints
           verbs:
@@ -239,6 +240,7 @@ spec:
                     memory: 20Mi
                 securityContext:
                   allowPrivilegeEscalation: false
+              hostNetwork: true
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: dpu-network-operator-controller-manager

--- a/bundle/manifests/dpu.openshift.io_ovnkubeconfigs.yaml
+++ b/bundle/manifests/dpu.openshift.io_ovnkubeconfigs.yaml
@@ -99,13 +99,14 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
+                    \n \ttype FooStatus struct{ \t    // Represents the observations
+                    of a foo's current state. \t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\" \t    //
+                    +patchMergeKey=type \t    // +patchStrategy=merge \t    // +listType=map
+                    \t    // +listMapKey=type \t    Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n \t    // other fields
+                    \t}"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -62,4 +62,5 @@ spec:
             cpu: 100m
             memory: 20Mi
       serviceAccountName: controller-manager
+      hostNetwork: true
       terminationGracePeriodSeconds: 10

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -108,6 +108,7 @@ rules:
   - security.openshift.io
   resourceNames:
   - anyuid
+  - hostnetwork
   resources:
   - securitycontextconstraints
   verbs:

--- a/controllers/ovnkubeconfig_controller.go
+++ b/controllers/ovnkubeconfig_controller.go
@@ -81,7 +81,7 @@ type OVNKubeConfigReconciler struct {
 //+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=machineconfiguration.openshift.io,resources=machineconfigpools,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=machineconfiguration.openshift.io,resources=machineconfigs,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=anyuid,verbs=use
+//+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=anyuid;hostnetwork,verbs=use
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
    We should run on host network in order to be able to run normally in infra cluster
    Currently after enabling ovn offload we can't run pods on infra cluster
    that are not using host network, so each operator restart will cause it
    to stuck.
    Another issue is dns resolution to tenant cluster as currently we set in
    etc hosts as workaround
