### PR TITLE
Add POD_NAME env to ovnkube-node

### DIFF
--- a/bindata/ovnkube-node/daemonset.yaml
+++ b/bindata/ovnkube-node/daemonset.yaml
@@ -162,6 +162,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
         ports:
         - name: metrics-port
           containerPort: 29103

--- a/bundle/manifests/dpu-network-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dpu-network-operator.clusterserviceversion.yaml
@@ -25,7 +25,7 @@ metadata:
     categories: OpenShift Optional, Networking
     certified: "false"
     containerImage: quay.io/openshift/origin-dpu-network-operator:4.13
-    createdAt: "2023-02-10T20:53:20Z"
+    createdAt: "2023-04-13T12:59:12Z"
     description: The operator is responsible for the life-cycle management of the
       ovn-kube components and the necessary host network initialization on DPU cards.
     olm.skipRange: '>=4.10.0-0 <4.13.0'


### PR DESCRIPTION
Without POD_NAME set, ovnkube-node will throw and error when generating the proxier health server.