### PR TITLE
Delete blocking deployment if tenant node doesn't exist anymore

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -30,3 +30,8 @@ func GetOrCreateObject(cl client.Client, expected client.Object, log logrus.Fiel
 
 	return obj, err
 }
+
+func DeleteObject(cl client.Client, obj client.Object) error {
+	err := cl.Delete(context.TODO(), obj)
+	return client.IgnoreNotFound(err)
+}


### PR DESCRIPTION
Delete blocking deployment in case tenant node was removed and doesn't exists anymore.
In case dpu worker was removed we should not block drain anymore, in order to do it we need to cleanup pbd/deployment