### PR TITLE
OCPBUGS-13694: Put both interfaces into swithdev mode

### DIFF
--- a/bindata/machine-config/files/sriov_config.json.yaml
+++ b/bindata/machine-config/files/sriov_config.json.yaml
@@ -3,4 +3,4 @@ overwrite: true
 path: "/etc/sriov_config.json"
 contents:
   inline: |
-    {"interfaces":[{"pciAddress":"0000:03:00.0","name":"enp3s0f0","eSwitchMode":"switchdev"}]}
+    {"interfaces":[{"pciAddress":"0000:03:00.0","name":"enp3s0f0","eSwitchMode":"switchdev"}, {"pciAddress":"0000:03:00.1","name":"enp3s0f1","eSwitchMode":"switchdev"}]}


### PR DESCRIPTION
By putting both ports into switchdev mode, two things are accomplished:

1. Driver doesn't time out anymore during boot on one of the ports. This makes the boot process unnecessarily slow.
2. Allows to use a firmware reset from the host side with the --sync option. This is required to change the number of virtual functions without power cycling the host.