### PR TITLE
OCPBUGS-14099: Update default installation namespace

### DIFF
--- a/bundle/manifests/dpu-network-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/dpu-network-operator.clusterserviceversion.yaml
@@ -29,6 +29,7 @@ metadata:
     description: The operator is responsible for the life-cycle management of the
       ovn-kube components and the necessary host network initialization on DPU cards.
     olm.skipRange: '>=4.10.0-0 <4.13.0'
+    operatorframework.io/suggested-namespace: openshift-dpu-network-operator
     operators.operatorframework.io/builder: operator-sdk-v1.26.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/dpu-network-operator

--- a/config/manifests/bases/dpu-network-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/dpu-network-operator.clusterserviceversion.yaml
@@ -11,6 +11,7 @@ metadata:
     description: The operator is responsible for the life-cycle management of the
       ovn-kube components and the necessary host network initialization on DPU cards.
     olm.skipRange: '>=4.10.0-0 <4.13.0'
+    operatorframework.io/suggested-namespace: openshift-dpu-network-operator
     operators.operatorframework.io/builder: operator-sdk-v1.13.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/openshift/dpu-network-operator


### PR DESCRIPTION
Currently, when installing the dpu-network-operator via the web console, the operator will be deploying in the "openshift-operators" namespace by default. Set this default to "openshift-dpu-network-operator" instead.